### PR TITLE
move environment variables to .env files

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,11 @@
+# OAuth settings
+# see: https://esri.github.io/arcgis-rest-js/guides/browser-authentication/
+# NOTE: the item for this application can be seen here:
+# http://www.arcgis.com/home/item.html?id=30d50f3d1d864ddc8b71ee06cfed242d
+# when deploying to your own domain, you should first
+# create your own item and register the URL where it will be deployed
+# and then use that application's App ID as the clientId below
+REACT_APP_CLIENT_ID=wy6Km7vd1dv6c4EG
+REACT_APP_PORTAL=https://www.arcgis.com/sharing/rest
+# app cookies will be prefixed with this, ex: caa_session
+REACT_APP_COOKIE_PREFIX=caa

--- a/src/config/environment.js
+++ b/src/config/environment.js
@@ -1,13 +1,6 @@
 export default {
-  // OAuth settings
-  // see: https://esri.github.io/arcgis-rest-js/guides/browser-authentication/
-  // NOTE: the item for this application can be seen here:
-  // http://www.arcgis.com/home/item.html?id=30d50f3d1d864ddc8b71ee06cfed242d
-  // when deploying to your own domain, you should first
-  // create your own item and register the URL where it will be deployed
-  // and then use that application's App ID as the clientId below
-  clientId: 'wy6Km7vd1dv6c4EG',
-  portal: 'https://www.arcgis.com/sharing/rest',
-  // app cookies will be prefixed with this, ex: caa_session
-  cookiePrefix: 'caa'
+  // NOTE: these environment variables are defined in .env file(s)
+  clientId: process.env.REACT_APP_CLIENT_ID,
+  portal: process.env.REACT_APP_PORTAL,
+  cookiePrefix: process.env.REACT_APP_COOKIE_PREFIX
 };


### PR DESCRIPTION
As per: https://facebook.github.io/create-react-app/docs/adding-custom-environment-variables

I left `config/environment.js` as a wrapper to emulate how environment variables are accessed in Ember.
