### PR TITLE
Revert "import esri styles from CSS instead of lazy-loading them"

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,7 +1,3 @@
-/* import esri styles */
-/* TODO: these should be lazy loaed by esri-loader's loadModules() */
-@import url('https://js.arcgis.com/4.10/esri/css/main.css');
-
 /* global styles */
 body {
   padding-top: 3.5rem;

--- a/src/utils/map.js
+++ b/src/utils/map.js
@@ -17,10 +17,9 @@ export function coordsToExtent(coords) {
 }
 
 export function newMap(element, mapOptions) {
-  // lazy-load the map modules
+  // lazy-load the map modules and CSS
   return loadModules(['esri/Map', 'esri/views/MapView', 'esri/Graphic'], {
-    // TODO: also lazy-load the CSS
-    // css: 'https://js.arcgis.com/4.10/esri/css/main.css'
+    css: 'https://js.arcgis.com/4.10/esri/css/main.css'
   }).then(([Map, MapView, Graphic]) => {
     // show the map at the element
     const map = new Map(mapOptions);


### PR DESCRIPTION
This reverts commit 3218bf4723978285af22ce5cf81fa56819c2ca1f.

That commit commit was only for the sake of comparison w/ the ember app. This is a much better way of loading esri styles.